### PR TITLE
Bugfix/various

### DIFF
--- a/src/main/frontend/model/hops/createChildNode.ts
+++ b/src/main/frontend/model/hops/createChildNode.ts
@@ -4,6 +4,7 @@ export interface Type extends AnyHop {
 	type: 'createChildNode';
 	name: string;
 	primaryType?: string;
+	runOnExistingNode: boolean;
 	conflict: ConflictResolutionStrategy;
 	hops?: Hop[];
 }
@@ -11,6 +12,7 @@ export interface Type extends AnyHop {
 export const defaultConfig: Partial<Type> = {
 	conflict: 'ignore',
 	name: 'child-name',
+	runOnExistingNode: false,
 };
 
 export const title = 'Create Node';

--- a/src/main/frontend/sections/editor/types/CreateChildNodeStep.tsx
+++ b/src/main/frontend/sections/editor/types/CreateChildNodeStep.tsx
@@ -41,6 +41,7 @@ export const CreateChildNodeStep = forwardRef<HTMLDivElement, { parentHops: Hop[
 				<Switch
 					label="Run on existing node"
 					value={hop.runOnExistingNode}
+					disabled={!hop.hops?.length}
 					onChange={runOnExistingNode => (hop.runOnExistingNode = runOnExistingNode)}
 				/>
 			) : undefined}
@@ -64,8 +65,8 @@ export const CreateChildNodeStep = forwardRef<HTMLDivElement, { parentHops: Hop[
 				<p>How to handle the case where the target node already exists.</p>
 				<h5>Run on existing node</h5>
 				<p>
-					Whether to run the descendant hops if the target node already existed (only applicable if “If the target node
-					exists” is set to “Ignore conflict”).
+					Whether to run the descendant hops if the target node already existed and no new node could be created (only
+					applicable if “If the target node exists” is set to “Ignore conflict”).
 				</p>
 			</Help>
 		</StepEditor>

--- a/src/main/frontend/sections/editor/types/CreateChildNodeStep.tsx
+++ b/src/main/frontend/sections/editor/types/CreateChildNodeStep.tsx
@@ -8,6 +8,7 @@ import { Help } from '../../../widgets/Help';
 import { Input } from '../../../widgets/Input';
 import { Pipeline } from '../Pipeline';
 import { Conflict } from '../../../widgets/Conflict';
+import { Switch } from '../../../widgets/Switch';
 
 export const CreateChildNodeStep = forwardRef<HTMLDivElement, { parentHops: Hop[]; hop: Type }>(function CreateChildNodeStep(
 	{ parentHops, hop },
@@ -32,9 +33,17 @@ export const CreateChildNodeStep = forwardRef<HTMLDivElement, { parentHops: Hop[
 			<Conflict
 				label="If the target node exists"
 				forceLabel="Replace the target node"
+				ignoreLabel="Ignore conflict"
 				value={hop.conflict ?? 'ignore'}
 				onChange={conflict => (hop.conflict = conflict)}
 			/>
+			{hop.conflict == 'ignore' ? (
+				<Switch
+					label="Run on existing node"
+					value={hop.runOnExistingNode}
+					onChange={runOnExistingNode => (hop.runOnExistingNode = runOnExistingNode)}
+				/>
+			) : undefined}
 			<Help title={title}>
 				<h5>Name of New Child Node</h5>
 				<p>The name of the child node to be created.</p>
@@ -52,10 +61,11 @@ export const CreateChildNodeStep = forwardRef<HTMLDivElement, { parentHops: Hop[
 					The primary type to set on the new node. If left empty, defaults to <code>nt:unstructured</code>
 				</p>
 				<h5>If the target node exists</h5>
+				<p>How to handle the case where the target node already exists.</p>
+				<h5>Run on existing node</h5>
 				<p>
-					How to handle the case where the target node already exists. Note that choosing “Ignore conflict” will use the
-					existing node to run descendent pipeline steps on. To stop the descendent pipeline from running in this case,
-					choose “Throw an exception” and place this step inside a “Catch Pipeline Errors” step.
+					Whether to run the descendant hops if the target node already existed (only applicable if “If the target node
+					exists” is set to “Ignore conflict”).
 				</p>
 			</Help>
 		</StepEditor>

--- a/src/main/frontend/widgets/Conflict.tsx
+++ b/src/main/frontend/widgets/Conflict.tsx
@@ -9,16 +9,23 @@ export type Options = [value: string, label: string, icon?: CoralIcon][];
 export const Conflict: FC<{
 	label?: string;
 	forceLabel?: string;
+	ignoreLabel?: string;
 	value: ConflictResolutionStrategy;
 	onChange(newValue: ConflictResolutionStrategy): void;
-}> = ({ label = 'Conflict Resolution', forceLabel = 'Force the given action', value, onChange }) => {
+}> = ({
+	label = 'Conflict Resolution',
+	forceLabel = 'Force the given action',
+	ignoreLabel = 'Ignore conflict, abort the current action',
+	value,
+	onChange,
+}) => {
 	return (
 		<Select
 			value={value}
 			label={label}
 			onChange={v => onChange(v)}
 			list={[
-				['ignore', 'Ignore conflict, abort the current action'],
+				['ignore', ignoreLabel],
 				['throw', 'Throw an exception, stop pipeline'],
 				['force', forceLabel],
 			]}

--- a/src/main/frontend/widgets/Switch.tsx
+++ b/src/main/frontend/widgets/Switch.tsx
@@ -7,9 +7,10 @@ export type Options = [value: string, label: string, icon?: CoralIcon][];
 
 export const Switch: FC<{
 	label?: string;
+	disabled?: boolean;
 	value: boolean;
 	onChange(newValue: boolean): void;
-}> = ({ label = 'Conflict Resolution', value, onChange }) => {
+}> = ({ label = 'Conflict Resolution', disabled = false, value, onChange }) => {
 	const scriptContext = useContext(ScriptContext);
 
 	const switchRef = useRef<HTMLInputElement>(null);
@@ -34,7 +35,7 @@ export const Switch: FC<{
 	return (
 		<label>
 			<span>{label}: </span>
-			<coral-switch ref={switchRef} checked={value ? true : undefined} />
+			<coral-switch ref={switchRef} checked={value ? true : undefined} disabled={disabled ? true : undefined} />
 		</label>
 	);
 };

--- a/src/main/java/com/swisscom/aem/tools/impl/HopContextImpl.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/HopContextImpl.java
@@ -3,7 +3,6 @@ package com.swisscom.aem.tools.impl;
 import com.swisscom.aem.tools.jcrhopper.HopperException;
 import com.swisscom.aem.tools.jcrhopper.config.Hop;
 import com.swisscom.aem.tools.jcrhopper.config.HopConfig;
-import com.swisscom.aem.tools.jcrhopper.config.LogLevel;
 import com.swisscom.aem.tools.jcrhopper.context.HopContext;
 import java.io.PrintWriter;
 import java.io.Writer;
@@ -13,21 +12,17 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.script.ScriptEngineManager;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.jexl3.JexlContext;
 import org.apache.commons.jexl3.JexlEngine;
 import org.apache.commons.jexl3.JxltEngine;
-import org.slf4j.Marker;
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.Logger;
 
 /**
  * Helper for hops to execute their actions.
  */
-@RequiredArgsConstructor
 @Slf4j
-@SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.ExcessivePublicCount", "PMD.TooManyMethods", "PMD.NcssCount" })
 public class HopContextImpl implements JexlContext, HopContext {
 
 	private final RunnerImpl runner;
@@ -42,6 +37,34 @@ public class HopContextImpl implements JexlContext, HopContext {
 
 	@SuppressWarnings("PMD.LooseCoupling")
 	private final HopVariables variables;
+
+	@Delegate(types = Logger.class)
+	private final Logger loggerImpl;
+
+	/**
+	 * Create a hop context.
+	 *
+	 * @param runner         the runner to use for reading the script properties and accessing the run handler
+	 * @param jexlEngine     the JEXL engine to use for expressions
+	 * @param templateEngine the JEXL template engine to use for string expressions
+	 * @param jcrFunctions   the <code>jcr:</code> helper implementation, useful to a few hop types
+	 * @param variables      the variable holder for this run
+	 */
+	@SuppressWarnings("PMD.LooseCoupling")
+	public HopContextImpl(
+		RunnerImpl runner,
+		JexlEngine jexlEngine,
+		JxltEngine templateEngine,
+		JcrFunctionsImpl jcrFunctions,
+		HopVariables variables
+	) {
+		this.runner = runner;
+		this.jexlEngine = jexlEngine;
+		this.templateEngine = templateEngine;
+		this.jcrFunctions = jcrFunctions;
+		this.variables = variables;
+		loggerImpl = new HopContextLogger(runner.getScript().getLogLevel(), runner.getRunHandler());
+	}
 
 	@Override
 	public void runHops(Node node, Iterable<HopConfig> hops) throws HopperException, RepositoryException {
@@ -96,6 +119,26 @@ public class HopContextImpl implements JexlContext, HopContext {
 		return new HopContextImpl(runner, jexlEngine, jexlEngine.createJxltEngine(), jcrFunctions, childVariables);
 	}
 
+	@Override
+	public void setVariable(String name, Object value) {
+		set(name, value);
+	}
+
+	@Override
+	public Map<String, Object> getVariables() {
+		return Collections.unmodifiableMap(variables);
+	}
+
+	@Override
+	public void print(String message) {
+		runner.getRunHandler().print(message);
+	}
+
+	@Override
+	public ScriptEngineManager getScriptEngineManager() {
+		return runner.getScriptEngineManager();
+	}
+
 	// region JEXL Context Accessors
 	@Override
 	public Object get(String key) {
@@ -113,524 +156,6 @@ public class HopContextImpl implements JexlContext, HopContext {
 	}
 
 	//endregion
-
-	@Override
-	public void setVariable(String name, Object value) {
-		set(name, value);
-	}
-
-	@Override
-	public Map<String, Object> getVariables() {
-		return Collections.unmodifiableMap(variables);
-	}
-
-	@Override
-	public ScriptEngineManager getScriptEngineManager() {
-		return runner.getScriptEngineManager();
-	}
-
-	// region Logging functions
-	@Override
-	public String getName() {
-		return log.getName();
-	}
-
-	@Override
-	public boolean isTraceEnabled() {
-		return LogLevel.TRACE.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public boolean isTraceEnabled(Marker marker) {
-		return LogLevel.TRACE.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public void trace(String s) {
-		if (isTraceEnabled()) {
-			log.trace(s);
-			runner.getRunHandler().log(LogLevel.TRACE, s, null, null);
-		}
-	}
-
-	@Override
-	public void trace(String s, Object o) {
-		if (isTraceEnabled()) {
-			log.trace(s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void trace(String s, Object o, Object o1) {
-		if (isTraceEnabled()) {
-			log.trace(s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void trace(String s, Object... objects) {
-		if (isTraceEnabled()) {
-			log.trace(s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void trace(String s, Throwable throwable) {
-		if (isTraceEnabled()) {
-			log.trace(s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void trace(Marker marker, String s) {
-		if (isTraceEnabled(marker)) {
-			log.trace(marker, s);
-			runner.getRunHandler().log(LogLevel.TRACE, s, null, marker);
-		}
-	}
-
-	@Override
-	public void trace(Marker marker, String s, Object o) {
-		if (isTraceEnabled(marker)) {
-			log.trace(marker, s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void trace(Marker marker, String s, Object o, Object o1) {
-		if (isTraceEnabled(marker)) {
-			log.trace(marker, s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void trace(Marker marker, String s, Object... objects) {
-		if (isTraceEnabled(marker)) {
-			log.trace(marker, s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void trace(Marker marker, String s, Throwable throwable) {
-		if (isTraceEnabled(marker)) {
-			log.trace(marker, s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public boolean isDebugEnabled() {
-		return LogLevel.DEBUG.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public boolean isDebugEnabled(Marker marker) {
-		return LogLevel.DEBUG.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public void debug(String s) {
-		if (isDebugEnabled()) {
-			log.debug(s);
-			runner.getRunHandler().log(LogLevel.DEBUG, s, null, null);
-		}
-	}
-
-	@Override
-	public void debug(String s, Object o) {
-		if (isDebugEnabled()) {
-			log.debug(s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void debug(String s, Object o, Object o1) {
-		if (isDebugEnabled()) {
-			log.debug(s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void debug(String s, Object... objects) {
-		if (isDebugEnabled()) {
-			log.debug(s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void debug(String s, Throwable throwable) {
-		if (isDebugEnabled()) {
-			log.debug(s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void debug(Marker marker, String s) {
-		if (isDebugEnabled(marker)) {
-			log.debug(marker, s);
-			runner.getRunHandler().log(LogLevel.DEBUG, s, null, marker);
-		}
-	}
-
-	@Override
-	public void debug(Marker marker, String s, Object o) {
-		if (isDebugEnabled(marker)) {
-			log.debug(marker, s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void debug(Marker marker, String s, Object o, Object o1) {
-		if (isDebugEnabled(marker)) {
-			log.debug(marker, s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void debug(Marker marker, String s, Object... objects) {
-		if (isDebugEnabled(marker)) {
-			log.debug(marker, s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void debug(Marker marker, String s, Throwable throwable) {
-		if (isDebugEnabled(marker)) {
-			log.debug(marker, s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public boolean isInfoEnabled() {
-		return LogLevel.INFO.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public boolean isInfoEnabled(Marker marker) {
-		return LogLevel.INFO.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public void info(String s) {
-		if (isInfoEnabled()) {
-			log.info(s);
-			runner.getRunHandler().log(LogLevel.INFO, s, null, null);
-		}
-	}
-
-	@Override
-	public void info(String s, Object o) {
-		if (isInfoEnabled()) {
-			log.info(s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void info(String s, Object o, Object o1) {
-		if (isInfoEnabled()) {
-			log.info(s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void info(String s, Object... objects) {
-		if (isInfoEnabled()) {
-			log.info(s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void info(String s, Throwable throwable) {
-		if (isInfoEnabled()) {
-			log.info(s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void info(Marker marker, String s) {
-		if (isInfoEnabled(marker)) {
-			log.info(marker, s);
-			runner.getRunHandler().log(LogLevel.INFO, s, null, marker);
-		}
-	}
-
-	@Override
-	public void info(Marker marker, String s, Object o) {
-		if (isInfoEnabled(marker)) {
-			log.info(marker, s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void info(Marker marker, String s, Object o, Object o1) {
-		if (isInfoEnabled(marker)) {
-			log.info(marker, s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void info(Marker marker, String s, Object... objects) {
-		if (isInfoEnabled(marker)) {
-			log.info(marker, s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void info(Marker marker, String s, Throwable throwable) {
-		if (isInfoEnabled(marker)) {
-			log.info(marker, s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public boolean isWarnEnabled() {
-		return LogLevel.WARN.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public boolean isWarnEnabled(Marker marker) {
-		return LogLevel.WARN.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public void warn(String s) {
-		if (isWarnEnabled()) {
-			log.warn(s);
-			runner.getRunHandler().log(LogLevel.WARN, s, null, null);
-		}
-	}
-
-	@Override
-	public void warn(String s, Object o) {
-		if (isWarnEnabled()) {
-			log.warn(s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void warn(String s, Object o, Object o1) {
-		if (isWarnEnabled()) {
-			log.warn(s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void warn(String s, Object... objects) {
-		if (isWarnEnabled()) {
-			log.warn(s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void warn(String s, Throwable throwable) {
-		if (isWarnEnabled()) {
-			log.warn(s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void warn(Marker marker, String s) {
-		if (isWarnEnabled(marker)) {
-			log.warn(marker, s);
-			runner.getRunHandler().log(LogLevel.WARN, s, null, marker);
-		}
-	}
-
-	@Override
-	public void warn(Marker marker, String s, Object o) {
-		if (isWarnEnabled(marker)) {
-			log.warn(marker, s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void warn(Marker marker, String s, Object o, Object o1) {
-		if (isWarnEnabled(marker)) {
-			log.warn(marker, s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void warn(Marker marker, String s, Object... objects) {
-		if (isWarnEnabled(marker)) {
-			log.warn(marker, s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void warn(Marker marker, String s, Throwable throwable) {
-		if (isWarnEnabled(marker)) {
-			log.warn(marker, s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public boolean isErrorEnabled() {
-		return LogLevel.ERROR.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public boolean isErrorEnabled(Marker marker) {
-		return LogLevel.ERROR.shouldLogTo(runner.getScript().getLogLevel());
-	}
-
-	@Override
-	public void error(String s) {
-		if (isErrorEnabled()) {
-			log.error(s);
-			runner.getRunHandler().log(LogLevel.ERROR, s, null, null);
-		}
-	}
-
-	@Override
-	public void error(String s, Object o) {
-		if (isErrorEnabled()) {
-			log.error(s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void error(String s, Object o, Object o1) {
-		if (isErrorEnabled()) {
-			log.error(s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void error(String s, Object... objects) {
-		if (isErrorEnabled()) {
-			log.error(s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void error(String s, Throwable throwable) {
-		if (isErrorEnabled()) {
-			log.error(s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
-		}
-	}
-
-	@Override
-	public void error(Marker marker, String s) {
-		if (isErrorEnabled(marker)) {
-			log.error(marker, s);
-			runner.getRunHandler().log(LogLevel.ERROR, s, null, marker);
-		}
-	}
-
-	@Override
-	public void error(Marker marker, String s, Object o) {
-		if (isErrorEnabled(marker)) {
-			log.error(marker, s, o);
-			final FormattingTuple format = MessageFormatter.format(s, o);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void error(Marker marker, String s, Object o, Object o1) {
-		if (isErrorEnabled(marker)) {
-			log.error(marker, s, o, o1);
-			final FormattingTuple format = MessageFormatter.format(s, o, o1);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void error(Marker marker, String s, Object... objects) {
-		if (isErrorEnabled(marker)) {
-			log.error(marker, s, objects);
-			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	@Override
-	public void error(Marker marker, String s, Throwable throwable) {
-		if (isErrorEnabled(marker)) {
-			log.error(marker, s, throwable);
-			final FormattingTuple format = MessageFormatter.format(s, throwable);
-			runner.getRunHandler().log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
-		}
-	}
-
-	// endregion
-
-	@Override
-	public void print(String message) {
-		runner.getRunHandler().print(message);
-	}
 
 	// region Writer
 	@Override

--- a/src/main/java/com/swisscom/aem/tools/impl/HopContextLogger.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/HopContextLogger.java
@@ -1,0 +1,514 @@
+package com.swisscom.aem.tools.impl;
+
+import com.swisscom.aem.tools.jcrhopper.config.LogLevel;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+@RequiredArgsConstructor
+@Slf4j
+@SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.ExcessivePublicCount", "PMD.TooManyMethods" })
+public class HopContextLogger implements Logger {
+
+	private final LogLevel logLevel;
+	private final RunHandler runHandler;
+
+	@Override
+	public String getName() {
+		return log.getName();
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return LogLevel.TRACE.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public boolean isTraceEnabled(Marker marker) {
+		return LogLevel.TRACE.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public void trace(String s) {
+		if (isTraceEnabled()) {
+			log.trace(s);
+			runHandler.log(LogLevel.TRACE, s, null, null);
+		}
+	}
+
+	@Override
+	public void trace(String s, Object o) {
+		if (isTraceEnabled()) {
+			log.trace(s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void trace(String s, Object o, Object o1) {
+		if (isTraceEnabled()) {
+			log.trace(s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void trace(String s, Object... objects) {
+		if (isTraceEnabled()) {
+			log.trace(s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void trace(String s, Throwable throwable) {
+		if (isTraceEnabled()) {
+			log.trace(s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void trace(Marker marker, String s) {
+		if (isTraceEnabled(marker)) {
+			log.trace(marker, s);
+			runHandler.log(LogLevel.TRACE, s, null, marker);
+		}
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Object o) {
+		if (isTraceEnabled(marker)) {
+			log.trace(marker, s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Object o, Object o1) {
+		if (isTraceEnabled(marker)) {
+			log.trace(marker, s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Object... objects) {
+		if (isTraceEnabled(marker)) {
+			log.trace(marker, s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void trace(Marker marker, String s, Throwable throwable) {
+		if (isTraceEnabled(marker)) {
+			log.trace(marker, s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.TRACE, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return LogLevel.DEBUG.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public boolean isDebugEnabled(Marker marker) {
+		return LogLevel.DEBUG.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public void debug(String s) {
+		if (isDebugEnabled()) {
+			log.debug(s);
+			runHandler.log(LogLevel.DEBUG, s, null, null);
+		}
+	}
+
+	@Override
+	public void debug(String s, Object o) {
+		if (isDebugEnabled()) {
+			log.debug(s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void debug(String s, Object o, Object o1) {
+		if (isDebugEnabled()) {
+			log.debug(s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void debug(String s, Object... objects) {
+		if (isDebugEnabled()) {
+			log.debug(s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void debug(String s, Throwable throwable) {
+		if (isDebugEnabled()) {
+			log.debug(s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void debug(Marker marker, String s) {
+		if (isDebugEnabled(marker)) {
+			log.debug(marker, s);
+			runHandler.log(LogLevel.DEBUG, s, null, marker);
+		}
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Object o) {
+		if (isDebugEnabled(marker)) {
+			log.debug(marker, s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Object o, Object o1) {
+		if (isDebugEnabled(marker)) {
+			log.debug(marker, s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Object... objects) {
+		if (isDebugEnabled(marker)) {
+			log.debug(marker, s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void debug(Marker marker, String s, Throwable throwable) {
+		if (isDebugEnabled(marker)) {
+			log.debug(marker, s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.DEBUG, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return LogLevel.INFO.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public boolean isInfoEnabled(Marker marker) {
+		return LogLevel.INFO.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public void info(String s) {
+		if (isInfoEnabled()) {
+			log.info(s);
+			runHandler.log(LogLevel.INFO, s, null, null);
+		}
+	}
+
+	@Override
+	public void info(String s, Object o) {
+		if (isInfoEnabled()) {
+			log.info(s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void info(String s, Object o, Object o1) {
+		if (isInfoEnabled()) {
+			log.info(s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void info(String s, Object... objects) {
+		if (isInfoEnabled()) {
+			log.info(s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void info(String s, Throwable throwable) {
+		if (isInfoEnabled()) {
+			log.info(s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void info(Marker marker, String s) {
+		if (isInfoEnabled(marker)) {
+			log.info(marker, s);
+			runHandler.log(LogLevel.INFO, s, null, marker);
+		}
+	}
+
+	@Override
+	public void info(Marker marker, String s, Object o) {
+		if (isInfoEnabled(marker)) {
+			log.info(marker, s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void info(Marker marker, String s, Object o, Object o1) {
+		if (isInfoEnabled(marker)) {
+			log.info(marker, s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void info(Marker marker, String s, Object... objects) {
+		if (isInfoEnabled(marker)) {
+			log.info(marker, s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void info(Marker marker, String s, Throwable throwable) {
+		if (isInfoEnabled(marker)) {
+			log.info(marker, s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.INFO, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return LogLevel.WARN.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public boolean isWarnEnabled(Marker marker) {
+		return LogLevel.WARN.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public void warn(String s) {
+		if (isWarnEnabled()) {
+			log.warn(s);
+			runHandler.log(LogLevel.WARN, s, null, null);
+		}
+	}
+
+	@Override
+	public void warn(String s, Object o) {
+		if (isWarnEnabled()) {
+			log.warn(s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void warn(String s, Object o, Object o1) {
+		if (isWarnEnabled()) {
+			log.warn(s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void warn(String s, Object... objects) {
+		if (isWarnEnabled()) {
+			log.warn(s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void warn(String s, Throwable throwable) {
+		if (isWarnEnabled()) {
+			log.warn(s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void warn(Marker marker, String s) {
+		if (isWarnEnabled(marker)) {
+			log.warn(marker, s);
+			runHandler.log(LogLevel.WARN, s, null, marker);
+		}
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Object o) {
+		if (isWarnEnabled(marker)) {
+			log.warn(marker, s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Object o, Object o1) {
+		if (isWarnEnabled(marker)) {
+			log.warn(marker, s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Object... objects) {
+		if (isWarnEnabled(marker)) {
+			log.warn(marker, s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void warn(Marker marker, String s, Throwable throwable) {
+		if (isWarnEnabled(marker)) {
+			log.warn(marker, s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.WARN, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return LogLevel.ERROR.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public boolean isErrorEnabled(Marker marker) {
+		return LogLevel.ERROR.shouldLogTo(logLevel);
+	}
+
+	@Override
+	public void error(String s) {
+		if (isErrorEnabled()) {
+			log.error(s);
+			runHandler.log(LogLevel.ERROR, s, null, null);
+		}
+	}
+
+	@Override
+	public void error(String s, Object o) {
+		if (isErrorEnabled()) {
+			log.error(s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void error(String s, Object o, Object o1) {
+		if (isErrorEnabled()) {
+			log.error(s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void error(String s, Object... objects) {
+		if (isErrorEnabled()) {
+			log.error(s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void error(String s, Throwable throwable) {
+		if (isErrorEnabled()) {
+			log.error(s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), null);
+		}
+	}
+
+	@Override
+	public void error(Marker marker, String s) {
+		if (isErrorEnabled(marker)) {
+			log.error(marker, s);
+			runHandler.log(LogLevel.ERROR, s, null, marker);
+		}
+	}
+
+	@Override
+	public void error(Marker marker, String s, Object o) {
+		if (isErrorEnabled(marker)) {
+			log.error(marker, s, o);
+			final FormattingTuple format = MessageFormatter.format(s, o);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void error(Marker marker, String s, Object o, Object o1) {
+		if (isErrorEnabled(marker)) {
+			log.error(marker, s, o, o1);
+			final FormattingTuple format = MessageFormatter.format(s, o, o1);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void error(Marker marker, String s, Object... objects) {
+		if (isErrorEnabled(marker)) {
+			log.error(marker, s, objects);
+			final FormattingTuple format = MessageFormatter.arrayFormat(s, objects);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+
+	@Override
+	public void error(Marker marker, String s, Throwable throwable) {
+		if (isErrorEnabled(marker)) {
+			log.error(marker, s, throwable);
+			final FormattingTuple format = MessageFormatter.format(s, throwable);
+			runHandler.log(LogLevel.ERROR, format.getMessage(), format.getThrowable(), marker);
+		}
+	}
+}

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/CopyNode.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/CopyNode.java
@@ -5,81 +5,82 @@ import com.swisscom.aem.tools.jcrhopper.config.ConflictResolution;
 import com.swisscom.aem.tools.jcrhopper.config.Hop;
 import com.swisscom.aem.tools.jcrhopper.config.HopConfig;
 import com.swisscom.aem.tools.jcrhopper.context.HopContext;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.jcr.ImportUUIDBehavior;
 import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
-import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.nodetype.NodeType;
+import javax.jcr.Session;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.With;
+import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.commons.xml.ToXmlContentHandler;
 import org.osgi.service.component.annotations.Component;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 @Slf4j
 @Component(service = Hop.class)
+@SuppressFBWarnings
 public class CopyNode implements Hop<CopyNode.Config> {
 
 	@Override
 	public void run(Config config, Node node, HopContext context) throws RepositoryException, HopperException {
-		final Node parent = node.getParent();
-		if (parent == null) {
-			context.error("Copying the root node isn’t allowed");
-			return;
+		if (StringUtils.equals(node.getPath(), "/")) {
+			throw new HopperException("Copying the root node isn’t allowed");
 		}
 
 		final String newName = context.evaluateTemplate(config.newName);
-		final MoveNode.NewNodeDescriptor descriptor = MoveNode.resolvePathToNewNode(parent, newName, config.conflict, context);
+		final MoveNode.NewNodeDescriptor descriptor = MoveNode.resolvePathToNewNode(node.getParent(), newName, config.conflict, context);
 		if (descriptor.isTargetExists()) {
 			return;
 		}
 
-		final String absolutePath = descriptor.getParent().getPath() + '/' + descriptor.getNewChildName();
-		context.info("Copying node from {} to {}", node.getPath(), absolutePath);
+		final Session session = node.getSession();
 
-		final Node copied = copyRecursive(node, descriptor.getParent(), descriptor.getNewChildName(), context);
-		context.runHops(copied, config.hops);
+		try {
+			final ByteArrayOutputStream os = new ByteArrayOutputStream();
+			final ToXmlContentHandler serializingContentHandler = new ToXmlContentHandler(os);
+			session.exportSystemView(
+				node.getPath(),
+				new RootRenamingContentHandler(serializingContentHandler, node.getName(), descriptor.getNewChildName()),
+				false,
+				false
+			);
+			// Remove the replaced node only after the snapshot has been taken because it’s possible it was part of the copied tree
+			descriptor.removeReplacedNode();
+
+			context.info("Copying node from {} to {}", node.getPath(), descriptor.getAbsolutePath());
+
+			session.importXML(
+				descriptor.getParent().getPath(),
+				new ByteArrayInputStream(os.toByteArray()),
+				ImportUUIDBehavior.IMPORT_UUID_CREATE_NEW
+			);
+		} catch (IOException | SAXException e) {
+			throw new HopperException("Importing the node at " + descriptor.getAbsolutePath() + " failed", e);
+		}
+
+		context.runHops(session.getNode(descriptor.getAbsolutePath()), config.hops);
 	}
 
 	@Nonnull
 	@Override
 	public Class<Config> getConfigType() {
 		return Config.class;
-	}
-
-	private Node copyRecursive(Node source, Node parent, String targetName, HopContext context) throws RepositoryException {
-		final Node target = parent.addNode(targetName, source.getPrimaryNodeType().getName());
-		for (NodeType mixin : source.getMixinNodeTypes()) {
-			target.addMixin(mixin.getName());
-		}
-		context.debug("Created {} node at {}", target.getPrimaryNodeType().getName(), target.getPath());
-		final PropertyIterator propIt = source.getProperties();
-		while (propIt.hasNext()) {
-			final Property prop = propIt.nextProperty();
-			try {
-				if (prop.isMultiple()) {
-					target.setProperty(prop.getName(), prop.getValues(), prop.getType());
-				} else {
-					target.setProperty(prop.getName(), prop.getValue(), prop.getType());
-				}
-			} catch (ConstraintViolationException ex) {
-				// Property is protected, assume it’s already covered implicitly by primary or mixin type
-				log.debug("Property {} is protected, skipping", prop.getName());
-			}
-		}
-		final NodeIterator nodeIt = source.getNodes();
-		while (nodeIt.hasNext()) {
-			final Node child = nodeIt.nextNode();
-			copyRecursive(child, target, child.getName(), context);
-		}
-		return target;
 	}
 
 	@Nonnull
@@ -103,5 +104,37 @@ public class CopyNode implements Hop<CopyNode.Config> {
 
 		@Nonnull
 		private List<HopConfig> hops = Collections.emptyList();
+	}
+
+	@RequiredArgsConstructor
+	private static final class RootRenamingContentHandler implements ContentHandler {
+
+		@Delegate(types = ContentHandler.class)
+		private final ContentHandler inner;
+
+		private final String oldName;
+		private final String newName;
+
+		private boolean isRootNode = true;
+
+		@Override
+		public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+			Attributes usedAttributes = atts;
+			if (isRootNode) {
+				final AttributesImpl attributesImpl = new AttributesImpl(usedAttributes);
+				final int index = attributesImpl.getIndex("sv:name");
+				if (index == -1) {
+					log.warn("sv:name attribute not found on element {}", qName);
+				} else if (StringUtils.equals(attributesImpl.getValue(index), oldName)) {
+					attributesImpl.setValue(index, newName);
+					usedAttributes = attributesImpl;
+				} else {
+					log.warn("sv:name expected to be {} but is {}", oldName, attributesImpl.getValue(index));
+				}
+			}
+
+			isRootNode = false;
+			inner.startElement(uri, localName, qName, usedAttributes);
+		}
 	}
 }

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/CopyNode.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/CopyNode.java
@@ -37,8 +37,7 @@ public class CopyNode implements Hop<CopyNode.Config> {
 
 		final String newName = context.evaluateTemplate(config.newName);
 		final MoveNode.NewNodeDescriptor descriptor = MoveNode.resolvePathToNewNode(parent, newName, config.conflict, context);
-		if (descriptor.isNeedsReplacing()) {
-			// Replacing not supported when copying
+		if (descriptor.isTargetExists()) {
 			return;
 		}
 

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/CreateChildNode.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/CreateChildNode.java
@@ -27,6 +27,7 @@ public class CreateChildNode implements Hop<CreateChildNode.Config> {
 		final String primaryType = context.evaluateTemplate(config.primaryType);
 
 		final MoveNode.NewNodeDescriptor descriptor = MoveNode.resolvePathToNewNode(node, name, config.conflict, context);
+		descriptor.removeReplacedNode();
 
 		final Node childNode;
 		if (descriptor.isTargetExists()) {

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/CreateChildNode.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/CreateChildNode.java
@@ -29,8 +29,20 @@ public class CreateChildNode implements Hop<CreateChildNode.Config> {
 		final MoveNode.NewNodeDescriptor descriptor = MoveNode.resolvePathToNewNode(node, name, config.conflict, context);
 
 		final Node childNode;
-		if (descriptor.isNeedsReplacing()) {
+		if (descriptor.isTargetExists()) {
+			if (!config.runOnExistingNode) {
+				return;
+			}
 			childNode = descriptor.getParent().getNode(descriptor.getNewChildName());
+			context.trace("Running the createChild hops on the existing node {}", childNode.getPath());
+			if (!childNode.isNodeType(config.primaryType)) {
+				context.warn(
+					"Existing node {} has type {} but {} was requested",
+					childNode.getPath(),
+					childNode.getPrimaryNodeType().getName(),
+					config.primaryType
+				);
+			}
 		} else {
 			context.info(
 				"Creating new node {} (type {}) under {}",
@@ -71,6 +83,8 @@ public class CreateChildNode implements Hop<CreateChildNode.Config> {
 
 		@Nonnull
 		private ConflictResolution conflict = ConflictResolution.IGNORE;
+
+		private boolean runOnExistingNode;
 
 		@Nonnull
 		private List<HopConfig> hops = Collections.emptyList();

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/Each.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/Each.java
@@ -58,6 +58,8 @@ public class Each implements Hop<Each.Config> {
 				node = (Node) item;
 			} else if (item instanceof String) {
 				node = context.getJcrFunctions().resolve((String) item);
+			} else {
+				node = null;
 			}
 			if (node == null) {
 				context.error("Iteration item {} could not be resolved as node", item);

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/Each.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/Each.java
@@ -5,6 +5,7 @@ import com.swisscom.aem.tools.jcrhopper.config.Hop;
 import com.swisscom.aem.tools.jcrhopper.config.HopConfig;
 import com.swisscom.aem.tools.jcrhopper.context.HopContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -37,8 +38,8 @@ public class Each implements Hop<Each.Config> {
 				runWith(config, ((Iterator<?>) items).next(), index++, node, context);
 			}
 		} else if (items.getClass().isArray()) {
-			for (Object item : (Object[]) items) {
-				runWith(config, item, index++, node, context);
+			for (index = 0; index < Array.getLength(items); index++) {
+				runWith(config, Array.get(items, index), index, node, context);
 			}
 		} else {
 			runWith(config, items, index, node, context);

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/MoveNode.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/MoveNode.java
@@ -126,7 +126,8 @@ public class MoveNode implements Hop<MoveNode.Config> {
 			return;
 		}
 
-		final String absolutePath = descriptor.getParent().getPath() + '/' + descriptor.getNewChildName();
+		final Node effectiveParent = descriptor.getParent();
+		final String absolutePath = StringUtils.stripEnd(effectiveParent.getPath(), "/") + '/' + descriptor.getNewChildName();
 		context.info("Moving node from {} to {}", node.getPath(), absolutePath);
 
 		node.getSession().move(node.getPath(), absolutePath);

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/MoveNode.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/MoveNode.java
@@ -62,8 +62,9 @@ public class MoveNode implements Hop<MoveNode.Config> {
 
 		parent = getParentNode(parts, parent, session, target);
 
-		final boolean needsReplacing = parent.hasNode(target);
-		if (needsReplacing) {
+		// FIXME: What about repositories with support for same-name siblings?
+		boolean targetExists = parent.hasNode(target);
+		if (targetExists) {
 			final Node childNode = parent.getNode(target);
 			switch (conflict) {
 				case IGNORE:
@@ -72,6 +73,7 @@ public class MoveNode implements Hop<MoveNode.Config> {
 				case FORCE:
 					context.info("Replacing existing node {}", childNode.getPath());
 					childNode.remove();
+					targetExists = false;
 					break;
 				case THROW:
 					throw new HopperException(String.format("Node %s already exists", childNode.getPath()));
@@ -80,7 +82,7 @@ public class MoveNode implements Hop<MoveNode.Config> {
 			}
 		}
 
-		return new NewNodeDescriptor(parent, target, needsReplacing);
+		return new NewNodeDescriptor(parent, target, targetExists);
 	}
 
 	private static Node getParentNode(List<String> parts, Node startParent, Session session, String target)
@@ -120,7 +122,7 @@ public class MoveNode implements Hop<MoveNode.Config> {
 		}
 
 		final NewNodeDescriptor descriptor = resolvePathToNewNode(parent, newName, config.conflict, context);
-		if (descriptor.getParent().hasNode(descriptor.getNewChildName())) {
+		if (descriptor.targetExists) {
 			return;
 		}
 
@@ -148,7 +150,7 @@ public class MoveNode implements Hop<MoveNode.Config> {
 
 		private final Node parent;
 		private final String newChildName;
-		private final boolean needsReplacing;
+		private final boolean targetExists;
 	}
 
 	@AllArgsConstructor

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/NodeQuery.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/NodeQuery.java
@@ -33,7 +33,7 @@ public class NodeQuery implements Hop<NodeQuery.Config> {
 		final Map<String, Object> resultVars = new HashMap<>();
 		final String statement = context.evaluateTemplate(config.query);
 		resultVars.put("query", statement);
-		context.trace("Running JCR query: {}", statement);
+		context.trace("Running {} JCR query: {}", config.queryType, statement);
 		final QueryResult result = getQueryResult(config, node, context, statement);
 		final RowIterator rowIterator = result.getRows();
 		final String[] selectors = result.getSelectorNames();

--- a/src/main/java/com/swisscom/aem/tools/impl/hops/NodeQuery.java
+++ b/src/main/java/com/swisscom/aem/tools/impl/hops/NodeQuery.java
@@ -71,7 +71,8 @@ public class NodeQuery implements Hop<NodeQuery.Config> {
 		return selectorName;
 	}
 
-	private QueryResult getQueryResult(Config config, Node node, HopContext context, String statement) throws RepositoryException {
+	private QueryResult getQueryResult(Config config, Node node, HopContext context, String statement)
+		throws RepositoryException, HopperException {
 		final QueryManager qm = node.getSession().getWorkspace().getQueryManager();
 		final Query query = qm.createQuery(statement, config.queryType);
 		if (config.limit > 0) {
@@ -86,7 +87,7 @@ public class NodeQuery implements Hop<NodeQuery.Config> {
 			if (value != null) {
 				query.bindValue(bindVar, context.getJcrFunctions().valueFromObject(value));
 			} else {
-				context.error("Could not bind placeholder {} as there is no known variable for it", bindVar);
+				throw new HopperException("Could not bind placeholder " + bindVar + " as there is no known variable for it");
 			}
 		}
 		return query.execute();

--- a/src/main/java/com/swisscom/aem/tools/jcrhopper/config/Script.java
+++ b/src/main/java/com/swisscom/aem/tools/jcrhopper/config/Script.java
@@ -51,6 +51,16 @@ public class Script {
 	/**
 	 * Create a script with the given hops and log level.
 	 *
+	 * @param logLevel the log level verbosity for printed messages
+	 * @param hops     the hops to configure for this script
+	 */
+	public Script(LogLevel logLevel, HopConfig... hops) {
+		this(Arrays.asList(hops), logLevel);
+	}
+
+	/**
+	 * Create a script with the given hops and log level.
+	 *
 	 * @param hops     the hops to configure for this script
 	 * @param logLevel the log level verbosity for printed messages
 	 */

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/ChildNodesTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/ChildNodesTest.java
@@ -1,0 +1,95 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.LogLevel;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
+import java.util.Collection;
+import java.util.Collections;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class ChildNodesTest {
+
+	public final AemContext context = new JcrOakAemContext();
+	private RunnerBuilder builder;
+	private Session session;
+	private RunHandler mockRunHandler;
+
+	@BeforeEach
+	public void setUp() {
+		context.create().resource("/content");
+		context.create().resource("/content/child-1");
+		context.create().resource("/content/child-2");
+		context.create().resource("/content/third-child");
+		context.create().resource("/content/other-child");
+
+		mockRunHandler = mock(RunHandler.class);
+		builder = Runner.builder().addHop(new ChildNodes()).runHandler(mockRunHandler);
+		session = context.resourceResolver().adaptTo(Session.class);
+	}
+
+	@Test
+	public void iterate_all() throws RepositoryException, HopperException {
+		builder.build(new Script(Collections.singletonList(new ChildNodes.Config()), LogLevel.DEBUG)).run(session.getNode("/content"), true);
+
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node third-child on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node other-child on /content", null, null);
+	}
+
+	@Test
+	public void iterate_wildcard() throws RepositoryException, HopperException {
+		builder
+			.build(new Script(Collections.singletonList(new ChildNodes.Config().withNamePattern("*")), LogLevel.DEBUG))
+			.run(session.getNode("/content"), true);
+
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node third-child on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node other-child on /content", null, null);
+	}
+
+	@Test
+	public void iterate_pattern() throws RepositoryException, HopperException {
+		builder
+			.build(new Script(Collections.singletonList(new ChildNodes.Config().withNamePattern("child-*")), LogLevel.DEBUG))
+			.run(session.getNode("/content"), true);
+
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
+		verify(mockRunHandler, never()).log(LogLevel.DEBUG, "Found child node third-child on /content", null, null);
+		verify(mockRunHandler, never()).log(LogLevel.DEBUG, "Found child node other-child on /content", null, null);
+	}
+
+	@Test
+	public void iterate_union() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					Collections.singletonList(new ChildNodes.Config().withNamePattern("child-* | third-child")),
+					LogLevel.DEBUG
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node third-child on /content", null, null);
+		verify(mockRunHandler, never()).log(LogLevel.DEBUG, "Found child node other-child on /content", null, null);
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/ChildNodesTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/ChildNodesTest.java
@@ -13,7 +13,6 @@ import com.swisscom.aem.tools.jcrhopper.config.Script;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
-import java.util.Collection;
 import java.util.Collections;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/ChildNodesTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/ChildNodesTest.java
@@ -13,7 +13,6 @@ import com.swisscom.aem.tools.jcrhopper.config.Script;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
-import java.util.Collections;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +42,7 @@ class ChildNodesTest {
 
 	@Test
 	public void iterate_all() throws RepositoryException, HopperException {
-		builder.build(new Script(Collections.singletonList(new ChildNodes.Config()), LogLevel.DEBUG)).run(session.getNode("/content"), true);
+		builder.build(new Script(LogLevel.DEBUG, new ChildNodes.Config())).run(session.getNode("/content"), true);
 
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
@@ -53,9 +52,7 @@ class ChildNodesTest {
 
 	@Test
 	public void iterate_wildcard() throws RepositoryException, HopperException {
-		builder
-			.build(new Script(Collections.singletonList(new ChildNodes.Config().withNamePattern("*")), LogLevel.DEBUG))
-			.run(session.getNode("/content"), true);
+		builder.build(new Script(LogLevel.DEBUG, new ChildNodes.Config().withNamePattern("*"))).run(session.getNode("/content"), true);
 
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
@@ -65,9 +62,7 @@ class ChildNodesTest {
 
 	@Test
 	public void iterate_pattern() throws RepositoryException, HopperException {
-		builder
-			.build(new Script(Collections.singletonList(new ChildNodes.Config().withNamePattern("child-*")), LogLevel.DEBUG))
-			.run(session.getNode("/content"), true);
+		builder.build(new Script(LogLevel.DEBUG, new ChildNodes.Config().withNamePattern("child-*"))).run(session.getNode("/content"), true);
 
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-2 on /content", null, null);
@@ -78,12 +73,7 @@ class ChildNodesTest {
 	@Test
 	public void iterate_union() throws RepositoryException, HopperException {
 		builder
-			.build(
-				new Script(
-					Collections.singletonList(new ChildNodes.Config().withNamePattern("child-* | third-child")),
-					LogLevel.DEBUG
-				)
-			)
+			.build(new Script(LogLevel.DEBUG, new ChildNodes.Config().withNamePattern("child-* | third-child")))
 			.run(session.getNode("/content"), true);
 
 		verify(mockRunHandler).log(LogLevel.DEBUG, "Found child node child-1 on /content", null, null);

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/CopyNodeTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/CopyNodeTest.java
@@ -3,13 +3,11 @@ package com.swisscom.aem.tools.impl.hops;
 import static com.swisscom.aem.tools.testsupport.AemUtil.childNames;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import com.swisscom.aem.tools.jcrhopper.HopperException;
 import com.swisscom.aem.tools.jcrhopper.Runner;
 import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
 import com.swisscom.aem.tools.jcrhopper.config.ConflictResolution;
-import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
 import com.swisscom.aem.tools.jcrhopper.config.Script;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/CopyNodeTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/CopyNodeTest.java
@@ -1,0 +1,228 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static com.swisscom.aem.tools.testsupport.AemUtil.childNames;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.ConflictResolution;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class CopyNodeTest {
+
+	public final AemContext context = new JcrOakAemContext();
+	private RunnerBuilder builder;
+	private Session session;
+
+	@BeforeEach
+	public void setUp() {
+		context.create().resource("/content", "prop1", 1, "prop2", "value2");
+		context.create().resource("/content/child-1", "jcr:primaryType", "cq:Page");
+		context.create().resource("/content/child-2");
+		context.create().resource("/content/third-child");
+		context.create().resource("/content/other-child");
+		context.create().resource("/existing");
+		context.create().resource("/existing/existing-child");
+
+		builder = Runner.builder().addHop(new CopyNode(), new CreateChildNode());
+		session = context.resourceResolver().adaptTo(Session.class);
+	}
+
+	@Test
+	public void copy_empty() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CopyNode.Config()
+						.withNewName("content2")
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		final ResourceResolver resolver = context.resourceResolver();
+		assertEquals(
+			Arrays.asList("child-1", "child-2", "third-child", "other-child", "new-child"),
+			childNames(resolver.getResource("/content2"))
+		);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("prop1", "prop2", "jcr:primaryType")),
+			resolver.getResource("/content2").getValueMap().keySet()
+		);
+
+		assertEquals("cq:Page", session.getNode("/content2/child-1").getPrimaryNodeType().getName());
+	}
+
+	@Test
+	public void copy_inside() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CopyNode.Config()
+						.withNewName("content/child-2/content2")
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		final ResourceResolver resolver = context.resourceResolver();
+		assertEquals(
+			Arrays.asList("child-1", "child-2", "third-child", "other-child", "new-child"),
+			childNames(resolver.getResource("/content/child-2/content2"))
+		);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("prop1", "prop2", "jcr:primaryType")),
+			resolver.getResource("/content/child-2/content2").getValueMap().keySet()
+		);
+
+		assertEquals("cq:Page", session.getNode("/content/child-2/content2/child-1").getPrimaryNodeType().getName());
+	}
+
+	@Test
+	public void copy_root() {
+		assertThrows(HopperException.class, () -> {
+			builder.build(new Script(new CopyNode.Config().withNewName("test-child"))).run(session.getRootNode(), true);
+		});
+	}
+
+	@Test
+	public void copy_existing_ignore() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CopyNode.Config()
+						.withNewName("existing")
+						.withConflict(ConflictResolution.IGNORE)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		final ResourceResolver resolver = context.resourceResolver();
+		assertEquals(Collections.singletonList("existing-child"), childNames(resolver.getResource("/existing")));
+	}
+
+	@Test
+	public void copy_existing_force() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CopyNode.Config()
+						.withNewName("existing")
+						.withConflict(ConflictResolution.FORCE)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		final ResourceResolver resolver = context.resourceResolver();
+		assertEquals(
+			Arrays.asList("child-1", "child-2", "third-child", "other-child", "new-child"),
+			childNames(resolver.getResource("/existing"))
+		);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("prop1", "prop2", "jcr:primaryType")),
+			resolver.getResource("/existing").getValueMap().keySet()
+		);
+
+		assertEquals("cq:Page", session.getNode("/existing/child-1").getPrimaryNodeType().getName());
+	}
+
+	@Test
+	public void copy_existing_throw() {
+		assertThrows(HopperException.class, () -> {
+			builder
+				.build(
+					new Script(
+						new CopyNode.Config()
+							.withNewName("existing")
+							.withConflict(ConflictResolution.THROW)
+							.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+					)
+				)
+				.run(session.getNode("/content"), true);
+		});
+	}
+
+	@Test
+	public void copy_existingInside_ignore() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CopyNode.Config()
+						.withNewName("content/child-1")
+						.withConflict(ConflictResolution.IGNORE)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		final ResourceResolver resolver = context.resourceResolver();
+		assertEquals(Collections.emptyList(), childNames(resolver.getResource("/content/child-1")));
+
+		assertEquals("cq:Page", session.getNode("/content/child-1").getPrimaryNodeType().getName());
+	}
+
+	@Test
+	public void copy_existingInside_force() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CopyNode.Config()
+						.withNewName("content/child-1")
+						.withConflict(ConflictResolution.FORCE)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+				)
+			)
+			.run(session.getNode("/content"), true);
+
+		final ResourceResolver resolver = context.resourceResolver();
+		assertEquals(
+			Arrays.asList("child-1", "child-2", "third-child", "other-child", "new-child"),
+			childNames(resolver.getResource("/content/child-1"))
+		);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("prop1", "prop2", "jcr:primaryType")),
+			resolver.getResource("/content/child-1").getValueMap().keySet()
+		);
+
+		assertEquals("cq:Page", session.getNode("/content/child-1/child-1").getPrimaryNodeType().getName());
+	}
+
+	@Test
+	public void copy_existingInside_throw() {
+		assertThrows(HopperException.class, () -> {
+			builder
+				.build(
+					new Script(
+						new CopyNode.Config()
+							.withNewName("content/child-1")
+							.withConflict(ConflictResolution.THROW)
+							.withHops(Collections.singletonList(new CreateChildNode.Config().withName("new-child")))
+					)
+				)
+				.run(session.getNode("/content"), true);
+		});
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/CreateChildNodeTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/CreateChildNodeTest.java
@@ -1,0 +1,117 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static com.swisscom.aem.tools.testsupport.AemUtil.childNames;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.ConflictResolution;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
+import java.util.Arrays;
+import java.util.Collections;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class CreateChildNodeTest {
+
+	public final AemContext context = new JcrOakAemContext();
+
+	private RunnerBuilder builder;
+	private Session session;
+
+	@BeforeEach
+	public void setUp() {
+		context.create().resource("/content");
+		context.create().resource("/content/child");
+		context.create().resource("/content/child/one");
+
+		builder = Runner.builder().addHop(new CreateChildNode());
+		session = context.resourceResolver().adaptTo(Session.class);
+	}
+
+	@Test
+	public void create_nonexisting() throws RepositoryException, HopperException {
+		builder.build(new Script(new CreateChildNode.Config().withName("child-two"))).run(session.getNode("/content"), true);
+
+		assertEquals(Arrays.asList("child", "child-two"), childNames(context.resourceResolver().getResource("/content")));
+		assertEquals("nt:unstructured", session.getNode("/content/child-two").getPrimaryNodeType().getName());
+	}
+
+	@Test
+	public void create_existing_abort() {
+		assertThrows(HopperException.class, () -> {
+			builder
+				.build(
+					new Script(
+						new CreateChildNode.Config().withName("child").withConflict(ConflictResolution.THROW),
+						new CreateChildNode.Config().withName("child2").withConflict(ConflictResolution.THROW)
+					)
+				)
+				.run(session.getNode("/content"), true);
+		});
+
+		assertEquals(Collections.singletonList("child"), childNames(context.resourceResolver().getResource("/content")));
+	}
+
+	@Test
+	public void create_existing_ignore_no_recurse() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CreateChildNode.Config()
+						.withName("child")
+						.withConflict(ConflictResolution.IGNORE)
+						.withRunOnExistingNode(false)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("../child3"))),
+					new CreateChildNode.Config().withName("child2").withConflict(ConflictResolution.THROW)
+				)
+			)
+			.run(session.getNode("/content"), true);
+		assertEquals(Arrays.asList("child", "child2"), childNames(context.resourceResolver().getResource("/content")));
+	}
+
+	@Test
+	public void create_existing_ignore_recurse() throws RepositoryException, HopperException {
+		builder
+			.build(
+				new Script(
+					new CreateChildNode.Config()
+						.withName("child")
+						.withConflict(ConflictResolution.IGNORE)
+						.withRunOnExistingNode(true)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("../child3"))),
+					new CreateChildNode.Config().withName("child2").withConflict(ConflictResolution.THROW)
+				)
+			)
+			.run(session.getNode("/content"), true);
+		assertEquals(Arrays.asList("child", "child3", "child2"), childNames(context.resourceResolver().getResource("/content")));
+	}
+
+	@Test
+	public void create_existing_force() throws RepositoryException, HopperException {
+		assertEquals("nt:unstructured", session.getNode("/content/child").getPrimaryNodeType().getName());
+		builder
+			.build(
+				new Script(
+					new CreateChildNode.Config()
+						.withName("child")
+						.withPrimaryType("cq:Page")
+						.withConflict(ConflictResolution.FORCE)
+						.withHops(Collections.singletonList(new CreateChildNode.Config().withName("../child3"))),
+					new CreateChildNode.Config().withName("child2").withConflict(ConflictResolution.THROW)
+				)
+			)
+			.run(session.getNode("/content"), true);
+		assertEquals(Arrays.asList("child", "child3", "child2"), childNames(context.resourceResolver().getResource("/content")));
+		assertEquals("cq:Page", session.getNode("/content/child").getPrimaryNodeType().getName());
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/CreateChildNodeTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/CreateChildNodeTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class CreateChildNodeTest {
 
 	public final AemContext context = new JcrOakAemContext();
-
 	private RunnerBuilder builder;
 	private Session session;
 

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/DeclareTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/DeclareTest.java
@@ -1,0 +1,90 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrMockAemContext;
+import java.util.Arrays;
+import java.util.Collections;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class DeclareTest {
+
+	public final AemContext context = new JcrMockAemContext();
+	private RunnerBuilder builder;
+	private RunHandler mockRunHandler;
+
+	@BeforeEach
+	public void setUp() {
+		mockRunHandler = mock(RunHandler.class);
+		builder = Runner.builder().addHop(new Declare(), new RunScript(), new Each()).runHandler(mockRunHandler);
+	}
+
+	@Test
+	public void declare_basic() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Declare.Config().withDeclarations(Collections.singletonMap("var1", "1")),
+					new RunScript.Config().withExtension("jexl").withCode("writer.print(var1)")
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("1");
+	}
+
+	@Test
+	public void declare_node() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Declare.Config().withDeclarations(Collections.singletonMap("node", "{'path': 1}")),
+					new RunScript.Config().withExtension("jexl").withCode("writer.print(node.path)")
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("/");
+	}
+
+	@Test
+	public void declare_override() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Declare.Config().withDeclarations(Collections.singletonMap("var1", "1")),
+					new RunScript.Config().withExtension("jexl").withCode("writer.print(`outer var1 before: ${var1}`)"),
+					new Each.Config()
+						.withExpression("[1]")
+						.withAssumeNodes(false)
+						.withHops(
+							Arrays.asList(
+								new Declare.Config().withDeclarations(Collections.singletonMap("var1", "2")),
+								new RunScript.Config()
+									.withExtension("jexl")
+									.withCode("writer.print(`inner var1: ${var1}`)")
+							)
+						),
+					new RunScript.Config().withExtension("jexl").withCode("writer.print(`outer var1 after: ${var1}`)")
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("outer var1 before: 1");
+		verify(mockRunHandler).print("inner var1: 2");
+		verify(mockRunHandler).print("outer var1 after: 1");
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/EachTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/EachTest.java
@@ -1,0 +1,152 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrMockAemContext;
+import java.util.Collections;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class EachTest {
+
+	public final AemContext context = new JcrMockAemContext();
+	private RunnerBuilder builder;
+	private RunHandler mockRunHandler;
+
+	@BeforeEach
+	public void setUp() {
+		context.create().resource("/content");
+		context.create().resource("/content/child-1");
+		context.create().resource("/content/child-2");
+		context.create().resource("/content/third-child");
+		context.create().resource("/content/other-child");
+
+		mockRunHandler = mock(RunHandler.class);
+		builder = Runner.builder().addHop(new Each(), new RunScript()).runHandler(mockRunHandler);
+	}
+
+	@Test
+	public void basic() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Each.Config()
+						.withExpression("['en-gb', 'en-us', 'en-ie']")
+						.withIterator("lang")
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config()
+									.withExtension("js")
+									.withCode(
+										"var items = lang.split('-');\nwriter.print(items[1].toUpperCase() + ': ' + items[0]);"
+									)
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("GB: en");
+		verify(mockRunHandler).print("US: en");
+		verify(mockRunHandler).print("IE: en");
+	}
+
+	@Test
+	public void primitive() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Each.Config()
+						.withExpression("[1, 2, 3, 4]")
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config().withExtension("js").withCode("writer.print(item*100);")
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("100");
+		verify(mockRunHandler).print("200");
+		verify(mockRunHandler).print("300");
+		verify(mockRunHandler).print("400");
+	}
+
+	@Test
+	public void node_string() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Each.Config()
+						.withExpression("[jcr:resolve(node, '/content/child-2'), jcr:resolve(node, '/content/third-child')]")
+						.withAssumeNodes(true)
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config().withExtension("js").withCode("writer.print(node.path);")
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("/content/child-2");
+		verify(mockRunHandler).print("/content/third-child");
+	}
+
+	@Test
+	public void node_refs() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Each.Config()
+						.withExpression("['/content', '/content/child-1', '/content/other-child']")
+						.withAssumeNodes(true)
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config().withExtension("js").withCode("writer.print(node.path);")
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("/content");
+		verify(mockRunHandler).print("/content/child-1");
+		verify(mockRunHandler).print("/content/other-child");
+	}
+
+	@Test
+	public void node_invalid() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new Each.Config()
+						.withExpression("[1, 2]")
+						.withAssumeNodes(true)
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config().withExtension("js").withCode("writer.print(node.path);")
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/").adaptTo(Node.class), true);
+
+		verify(mockRunHandler, never()).print(any());
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/FilterNodeTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/FilterNodeTest.java
@@ -1,0 +1,77 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrMockAemContext;
+import java.util.Collections;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class FilterNodeTest {
+
+	public final AemContext context = new JcrMockAemContext();
+	private RunnerBuilder builder;
+	private RunHandler mockRunHandler;
+
+	@BeforeEach
+	public void setUp() {
+		context.create().resource("/child-1");
+		context.create().resource("/other-child");
+
+		mockRunHandler = mock(RunHandler.class);
+		builder = Runner.builder().addHop(new FilterNode(), new RunScript()).runHandler(mockRunHandler).addUtil("str", StringUtils.class);
+	}
+
+	@Test
+	public void matches() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new FilterNode.Config()
+						.withExpression("str:startsWith(node.name, 'child-')")
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config().withExtension("jexl").withCode("writer.print(node.path)")
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/child-1").adaptTo(Node.class), true);
+
+		verify(mockRunHandler).print("/child-1");
+	}
+
+	@Test
+	public void doesNotMatch() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					new FilterNode.Config()
+						.withExpression("str:startsWith(node.name, 'child-')")
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config().withExtension("jexl").withCode("writer.print(node.path)")
+							)
+						)
+				)
+			)
+			.run(context.resourceResolver().getResource("/other-child").adaptTo(Node.class), true);
+
+		verify(mockRunHandler, never()).print(any());
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/MoveNodeTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/MoveNodeTest.java
@@ -1,0 +1,59 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static com.swisscom.aem.tools.testsupport.AemUtil.childNames;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
+import java.util.Arrays;
+import java.util.Collections;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class MoveNodeTest {
+
+	public final AemContext context = new JcrOakAemContext();
+	private RunnerBuilder builder;
+	private ResourceResolver resolver;
+	private Session session;
+
+	@BeforeEach
+	public void setUp() {
+		context.create().resource("/content");
+		context.create().resource("/content/test");
+		context.create().resource("/content/test/child2");
+		context.create().resource("/content/test/child1");
+
+		builder = Runner.builder().addHop(new MoveNode());
+
+		resolver = context.resourceResolver();
+		session = resolver.adaptTo(Session.class);
+	}
+
+	@Test
+	public void move_sameParent() throws RepositoryException, HopperException {
+		assertEquals(Arrays.asList("child2", "child1"), childNames(resolver.getResource("/content/test")));
+
+		builder.build(new Script(new MoveNode.Config().withNewName("child3"))).run(session.getNode("/content/test/child2"), true);
+
+		assertEquals(Arrays.asList("child3", "child1"), childNames(resolver.getResource("/content/test")));
+	}
+
+	@Test
+	public void move_newParent() throws RepositoryException, HopperException {
+		builder.build(new Script(new MoveNode.Config().withNewName("../test"))).run(session.getNode("/content/test"), true);
+
+		assertEquals(Arrays.asList("child2", "child1"), childNames(resolver.getResource("/test")));
+		assertEquals(Collections.emptyList(), childNames(resolver.getResource("/content")));
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/impl/hops/NodeQueryTest.java
+++ b/src/test/java/com/swisscom/aem/tools/impl/hops/NodeQueryTest.java
@@ -1,0 +1,295 @@
+package com.swisscom.aem.tools.impl.hops;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.swisscom.aem.tools.jcrhopper.HopperException;
+import com.swisscom.aem.tools.jcrhopper.Runner;
+import com.swisscom.aem.tools.jcrhopper.RunnerBuilder;
+import com.swisscom.aem.tools.jcrhopper.config.LogLevel;
+import com.swisscom.aem.tools.jcrhopper.config.RunHandler;
+import com.swisscom.aem.tools.jcrhopper.config.Script;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import io.wcm.testing.mock.aem.junit5.JcrOakAemContext;
+import java.util.Collections;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AemContextExtension.class)
+class NodeQueryTest {
+
+	public final AemContext context = new JcrOakAemContext();
+	private RunnerBuilder builder;
+	private Session session;
+	private RunHandler mockRunHandler;
+
+	@BeforeEach
+	public void setUp() throws RepositoryException {
+		context.create().resource("/content", "jcr:primaryType", "sling:Folder");
+		context.create().resource("/content/child", "jcr:primaryType", "cq:Page");
+		context.create().resource("/content/child/jcr:content", "jcr:primaryType", "cq:PageContent", "pageId", 1);
+		context.create().resource("/content/child/one", "jcr:primaryType", "cq:Page");
+		context.create().resource("/content/child/one/jcr:content", "jcr:primaryType", "cq:PageContent", "pageId", 2);
+
+		mockRunHandler = mock(RunHandler.class);
+		builder = Runner.builder().addHop(new NodeQuery(), new Declare(), new RunScript()).runHandler(mockRunHandler);
+		session = context.resourceResolver().adaptTo(Session.class);
+		session.save();
+	}
+
+	@Test
+	public void xpath() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new NodeQuery.Config().withQueryType("xpath").withQuery("/jcr:root/content//element(*, cq:Page)")
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child for xpath query /jcr:root/content//e…", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child/one for xpath query /jcr:root/content//e…", null, null);
+		verify(mockRunHandler).log(LogLevel.INFO, "Processed 2 nodes from xpath query /jcr:root/content//element(*, cq:Page)", null, null);
+	}
+
+	@Test
+	public void sql2() throws HopperException, RepositoryException {
+		builder
+			.build(new Script(LogLevel.DEBUG, new NodeQuery.Config().withQueryType(Query.JCR_SQL2).withQuery("SELECT * FROM [cq:Page]")))
+			.run(session, true);
+
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child for JCR-SQL2 query SELECT * FROM [cq:Pa…", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child/one for JCR-SQL2 query SELECT * FROM [cq:Pa…", null, null);
+		verify(mockRunHandler).log(LogLevel.INFO, "Processed 2 nodes from JCR-SQL2 query SELECT * FROM [cq:Page]", null, null);
+	}
+
+	@Test
+	public void sql2_preparedPlaceholder() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new Declare.Config().withDeclarations(Collections.singletonMap("pageId", "1")),
+					new NodeQuery.Config()
+						.withQueryType(Query.JCR_SQL2)
+						.withQuery("SELECT * FROM [cq:PageContent] WHERE pageId = $pageId")
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler).log(
+			LogLevel.DEBUG,
+			"Found node /content/child/jcr:content for JCR-SQL2 query SELECT * FROM [cq:Pa…",
+			null,
+			null
+		);
+		verify(mockRunHandler, never()).log(
+			LogLevel.DEBUG,
+			"Found node /content/child/one/jcr:content for JCR-SQL2 query SELECT * FROM [cq:Pa…",
+			null,
+			null
+		);
+		verify(mockRunHandler).log(
+			LogLevel.INFO,
+			"Processed 1 nodes from JCR-SQL2 query SELECT * FROM [cq:PageContent] WHERE pageId = $pageId",
+			null,
+			null
+		);
+	}
+
+	@Test
+	public void sql2_preparedPlaceholder_missing() {
+		assertThrows(HopperException.class, () ->
+			builder
+				.build(
+					new Script(
+						LogLevel.DEBUG,
+						new NodeQuery.Config()
+							.withQueryType(Query.JCR_SQL2)
+							.withQuery("SELECT * FROM [cq:PageContent] WHERE pageId = $pageId")
+					)
+				)
+				.run(session, true)
+		);
+	}
+
+	@Test
+	public void sql2_templateExpression() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new Declare.Config().withDeclarations(Collections.singletonMap("pageId", "2")),
+					new NodeQuery.Config()
+						.withQueryType(Query.JCR_SQL2)
+						.withQuery("SELECT * FROM [cq:PageContent] WHERE pageId = ${pageId}")
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler).log(
+			LogLevel.DEBUG,
+			"Found node /content/child/one/jcr:content for JCR-SQL2 query SELECT * FROM [cq:Pa…",
+			null,
+			null
+		);
+		verify(mockRunHandler, never()).log(
+			LogLevel.DEBUG,
+			"Found node /content/child/jcr:content for JCR-SQL2 query SELECT * FROM [cq:Pa…",
+			null,
+			null
+		);
+		verify(mockRunHandler).log(
+			LogLevel.INFO,
+			"Processed 1 nodes from JCR-SQL2 query SELECT * FROM [cq:PageContent] WHERE pageId = 2",
+			null,
+			null
+		);
+	}
+
+	@Test
+	public void sql2_implicitJoin() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new NodeQuery.Config()
+						.withQueryType(Query.JCR_SQL2)
+						.withQuery(
+							"SELECT * FROM [cq:Page] AS page INNER JOIN [cq:PageContent] AS pageContent ON ISCHILDNODE(pageContent, page)"
+						)
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler).log(any(), startsWith("There are 2 selectors in the JCR-SQL2 query. "), any(), any());
+		verify(mockRunHandler).log(
+			LogLevel.DEBUG,
+			"Found node /content/child/jcr:content for JCR-SQL2 query SELECT * FROM [cq:Pa…",
+			null,
+			null
+		);
+		verify(mockRunHandler).log(
+			LogLevel.DEBUG,
+			"Found node /content/child/one/jcr:content for JCR-SQL2 query SELECT * FROM [cq:Pa…",
+			null,
+			null
+		);
+		verify(mockRunHandler).log(
+			LogLevel.INFO,
+			"Processed 2 nodes from JCR-SQL2 query SELECT * FROM [cq:Page] AS page INNER JOIN [cq:PageContent] AS pageContent ON ISCHILDNODE(pageContent, page)",
+			null,
+			null
+		);
+	}
+
+	@Test
+	public void sql2_explicitJoin() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new NodeQuery.Config()
+						.withQueryType(Query.JCR_SQL2)
+						.withQuery(
+							"SELECT * FROM [cq:Page] AS page INNER JOIN [cq:PageContent] AS pageContent ON ISCHILDNODE(pageContent, page)"
+						)
+						.withSelectorName("page")
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config()
+									.withCode(
+										"writer.print('#' + counter + ' page: ' + page.getPath() + ', pageContent: ' + pageContent.getPath())"
+									)
+							)
+						)
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler, never()).log(any(), startsWith("There are 2 selectors in the JCR-SQL2 query. "), any(), any());
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child for JCR-SQL2 query SELECT * FROM [cq:Pa…", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child/one for JCR-SQL2 query SELECT * FROM [cq:Pa…", null, null);
+		verify(mockRunHandler).log(
+			LogLevel.INFO,
+			"Processed 2 nodes from JCR-SQL2 query SELECT * FROM [cq:Page] AS page INNER JOIN [cq:PageContent] AS pageContent ON ISCHILDNODE(pageContent, page)",
+			null,
+			null
+		);
+
+		verify(mockRunHandler).print("#0 page: /content/child, pageContent: /content/child/jcr:content");
+		verify(mockRunHandler).print("#1 page: /content/child/one, pageContent: /content/child/one/jcr:content");
+	}
+
+	@Test
+	public void sql2_invalidSelector() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			builder
+				.build(
+					new Script(
+						LogLevel.DEBUG,
+						new NodeQuery.Config()
+							.withQueryType(Query.JCR_SQL2)
+							.withQuery("SELECT * FROM [cq:Page]")
+							.withSelectorName("test1")
+					)
+				)
+				.run(session, true);
+		});
+	}
+
+	@Test
+	public void sql2_customCounter() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new NodeQuery.Config()
+						.withQueryType(Query.JCR_SQL2)
+						.withQuery("SELECT * FROM [cq:Page]")
+						.withCounterName("cnt")
+						.withHops(
+							Collections.singletonList(
+								new RunScript.Config()
+									.withExtension("jexl")
+									.withCode("writer.print('#' + (cnt+1) + ' node: ' + node.getPath())")
+							)
+						)
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler).print("#1 node: /content/child");
+		verify(mockRunHandler).print("#2 node: /content/child/one");
+	}
+
+	@Test
+	public void sql2_limitAndOffset() throws HopperException, RepositoryException {
+		builder
+			.build(
+				new Script(
+					LogLevel.DEBUG,
+					new NodeQuery.Config()
+						.withQueryType(Query.JCR_SQL2)
+						.withQuery("SELECT * FROM [cq:Page]")
+						.withLimit(1)
+						.withOffset(1)
+				)
+			)
+			.run(session, true);
+
+		verify(mockRunHandler, never()).log(LogLevel.DEBUG, "Found node /content/child for JCR-SQL2 query SELECT * FROM [cq:Pa…", null, null);
+		verify(mockRunHandler).log(LogLevel.DEBUG, "Found node /content/child/one for JCR-SQL2 query SELECT * FROM [cq:Pa…", null, null);
+		verify(mockRunHandler).log(LogLevel.INFO, "Processed 1 nodes from JCR-SQL2 query SELECT * FROM [cq:Page]", null, null);
+	}
+}

--- a/src/test/java/com/swisscom/aem/tools/jcrhopper/RunnerTest.java
+++ b/src/test/java/com/swisscom/aem/tools/jcrhopper/RunnerTest.java
@@ -71,17 +71,15 @@ class RunnerTest {
 	public void simple() throws RepositoryException, HopperException {
 		final Runner runner = RUNNER_BUILDER.build(
 			new Script(
-				Arrays.asList(
-					new SetProperty.Config().withPropertyName("test").withValue("true"),
-					new CreateChildNode.Config()
-						.withName("cool-item")
-						.withHops(
-							Collections.singletonList(
-								new SetProperty.Config().withPropertyName("TestProp").withValue("'TestValue'")
-							)
+				LogLevel.TRACE,
+				new SetProperty.Config().withPropertyName("test").withValue("true"),
+				new CreateChildNode.Config()
+					.withName("cool-item")
+					.withHops(
+						Collections.singletonList(
+							new SetProperty.Config().withPropertyName("TestProp").withValue("'TestValue'")
 						)
-				),
-				LogLevel.TRACE
+					)
 			)
 		);
 
@@ -260,25 +258,21 @@ class RunnerTest {
 
 		final Runner runner = RUNNER_BUILDER.build(
 			new Script(
-				Arrays.asList(
-					new NodeQuery.Config()
-						.withQuery("SELECT * FROM [nt:unstructured] as n WHERE NAME(n) = 'test-item'")
-						.withCounterName("item")
-						.withHops(
-							Arrays.asList(
-								new SetProperty.Config().withPropertyName("index").withValue("item"),
-								new ChildNodes.Config()
-									.withHops(
-										Collections.singletonList(
-											new SetProperty.Config()
-												.withPropertyName("query")
-												.withValue("query")
-										)
+				LogLevel.TRACE,
+				new NodeQuery.Config()
+					.withQuery("SELECT * FROM [nt:unstructured] as n WHERE NAME(n) = 'test-item'")
+					.withCounterName("item")
+					.withHops(
+						Arrays.asList(
+							new SetProperty.Config().withPropertyName("index").withValue("item"),
+							new ChildNodes.Config()
+								.withHops(
+									Collections.singletonList(
+										new SetProperty.Config().withPropertyName("query").withValue("query")
 									)
-							)
+								)
 						)
-				),
-				LogLevel.TRACE
+					)
 			)
 		);
 

--- a/src/test/java/com/swisscom/aem/tools/jcrhopper/ScriptTest.java
+++ b/src/test/java/com/swisscom/aem/tools/jcrhopper/ScriptTest.java
@@ -41,8 +41,8 @@ class ScriptTest {
 		assertEquals(
 			"Script(hops=[" +
 			"SetProperty.Config(propertyName=sling:resourceType, value='swisscom/sdx/components/containers/tabs', conflict=FORCE), " +
-			"CreateChildNode.Config(name=contents, primaryType=nt:unstructured, conflict=IGNORE, hops=[" +
-			"CreateChildNode.Config(name=shared, primaryType=nt:unstructured, conflict=IGNORE, hops=[" +
+			"CreateChildNode.Config(name=contents, primaryType=nt:unstructured, conflict=IGNORE, runOnExistingNode=false, hops=[" +
+			"CreateChildNode.Config(name=shared, primaryType=nt:unstructured, conflict=IGNORE, runOnExistingNode=false, hops=[" +
 			"SetProperty.Config(propertyName=sling:resourceType, value='swisscom/sdx/components/responsivegrid', conflict=FORCE)" +
 			"])" +
 			"]), " +

--- a/src/test/java/com/swisscom/aem/tools/jcrhopper/osgi/RunnerServiceTest.java
+++ b/src/test/java/com/swisscom/aem/tools/jcrhopper/osgi/RunnerServiceTest.java
@@ -52,10 +52,8 @@ class RunnerServiceTest {
 
 		final Runner runner = runnerBuilder.build(
 			new Script(
-				Collections.singletonList(
-					new ResolveNode.Config().withName("/test").withHops(Collections.singletonList(new ChildNodes.Config()))
-				),
-				LogLevel.DEBUG
+				LogLevel.DEBUG,
+				new ResolveNode.Config().withName("/test").withHops(Collections.singletonList(new ChildNodes.Config()))
 			)
 		);
 

--- a/src/test/java/com/swisscom/aem/tools/testsupport/AemUtil.java
+++ b/src/test/java/com/swisscom/aem/tools/testsupport/AemUtil.java
@@ -1,0 +1,17 @@
+package com.swisscom.aem.tools.testsupport;
+
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.sling.api.resource.Resource;
+
+public final class AemUtil {
+
+	public static List<String> childNames(Resource parent) {
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(parent.listChildren(), Spliterator.ORDERED), false)
+			.map(Resource::getName)
+			.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
- Fine-grained control over running the sub-pipeline of a `createChildNode` hop when the child node already exists
- Fix bug when moving a node to the root
- Add tests for a few of the hop types not yet under test
- Keep order of renamed node (when `moveNode` is used to move to the same parent as before). Closes #16 
- Ensure `copyNode` gracefully handles all cases where a node was copied into itself
- Allow `each` to loop over primitive arrays