### PR TITLE
fix: use closest() in Picker to handle clicks on child elements

### DIFF
--- a/src/main/frontend/widgets/Picker.tsx
+++ b/src/main/frontend/widgets/Picker.tsx
@@ -1,6 +1,5 @@
 import React, { ButtonHTMLAttributes, FC, ReactNode, useEffect, useId, useRef, JSX } from 'react';
 import { Options } from './Select';
-import type { CoralIcon } from '../coral/custom-elements';
 
 export const Picker: FC<{
 	items: Options;
@@ -22,7 +21,8 @@ export const Picker: FC<{
 		}
 
 		function selectlistChanged(e: Event) {
-			const item = e.target as HTMLOptionElement;
+			const item = (e.target as HTMLElement).closest<HTMLElement & { value: string; selected: boolean }>('coral-selectlist-item');
+			if (!item) return;
 			popover!.open = false;
 			picked(item.value);
 			item.selected = false;


### PR DESCRIPTION
Fixes #43 - a `TypeError` on the script-builder page when clicking items in the `Picker` component that contain child elements (e.g. `coral-icon`). 

#### Problem

The `selectlistChanged` click handler in `Picker.tsx` cast `e.target `directly to the list item element. When a child element inside a `coral-selectlist-item` (such as a `coral-icon`) is clicked, `e.target `resolves to the child rather than the list item itself. This causes `item.value` to be `undefined`, leading to the following error in the browser console:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'config')
```

#### Solution
Use `.closest('coral-selectlist-item')` to traverse up from the actual click target to the nearest list item, regardless of which child element was clicked. If no list item is found (e.g. a click on the container itself), the handler returns early.

#### Changes
`src/main/frontend/widgets/Picker.tsx` - updated `selectlistChanged` to use `closest()` instead of a direct cast of `e.target`

#### Testing

- The visual regression tests failed. It seems the reference screenshots are outdated. @SwisscomHopperDevs need your guidance here (as they failed for `0.7.2` release as well)
- `./gradlew check` with `-x playwright` passed
- Manually verified on http://localhost:4502/apps/jcr-hopper/script-builder.html - clicking picker items no longer throws a TypeError